### PR TITLE
Makefile should put -lpthread in LDLIBS instead of LDFLAG

### DIFF
--- a/crashes/Makefile
+++ b/crashes/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.globals.inc
 
 CPPFLAGS += -I../include
 CFLAGS += -O2 -Wall
-LDFLAGS += -lpthread
+LDLIBS += -lpthread
 
 PAPI_INCLUDE = -I/usr/local/include
 PAPI_LIB = /usr/local/lib/libpapi.a

--- a/tests/attr_fields/Makefile
+++ b/tests/attr_fields/Makefile
@@ -2,7 +2,7 @@ include ../../Makefile.globals.inc
 
 CPPFLAGS += -I../../include
 CFLAGS += -Wall -O2 -g
-LDFLAGS += -lpthread
+LDLIBS += -lpthread
 LIB = ../../lib
 
 PROGRAM_LIST = \


### PR DESCRIPTION
The problem is that only symbols that have already been seen are
grabbed from libpthread, and the default recipe for linking a single
object file puts LDFLAGS at the start of the command line:

‘$(CC) $(LDFLAGS) n.o $(LOADLIBES) $(LDLIBS)’
https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html

Moving -lpthread to LDLIBS (or LOADLIBES) puts it at the end of the
command where it works.