### PR TITLE
Add test showing rdpmc of hardware counters occasionally jumping by 2^48

### DIFF
--- a/tests/rdpmc/Makefile
+++ b/tests/rdpmc/Makefile
@@ -9,7 +9,8 @@ PROGRAM_LIST = \
 	rdpmc_support \
 	rdpmc_validation \
 	rdpmc_comparision_readsyscall \
-	rdpmc_comparision_mmap
+	rdpmc_comparision_mmap \
+	rdpmc_jump
 
 all: $(PROGRAM_LIST)
 
@@ -21,6 +22,8 @@ rdpmc_validation: rdpmc_validation.o rdpmc_lib.o $(LIB)/libhelper.a
 rdpmc_comparision_readsyscall: rdpmc_comparision_readsyscall.o
 
 rdpmc_comparision_mmap: rdpmc_comparision_mmap.o
+
+rdpmc_jump: rdpmc_jump.o rdpmc_lib.o $(LIB)/libhelper.a
 
 install: all
 	$(INSTALL) -d $(prefix)/tests/rdpmc

--- a/tests/rdpmc/rdpmc_jump.c
+++ b/tests/rdpmc/rdpmc_jump.c
@@ -1,0 +1,82 @@
+char test_string[]="Testing if hardware counters exhibit unexpected jumps with rdpmc";
+int quiet=0;
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <errno.h>
+
+#include "perf_event.h"
+#include "test_utils.h"
+#include "perf_helpers.h"
+#include "instructions_testcode.h"
+
+#include "rdpmc_lib.h"
+
+#include <sys/mman.h>
+
+
+int main(/* int argc, char **argv */) {
+	int quiet = test_quiet();
+	int silent = quiet;
+
+	if (!quiet) printf("%s.\n", test_string);
+
+	if (!detect_rdpmc(quiet)) test_skip(test_string);
+
+	if (instructions_million() == CODE_UNIMPLEMENTED) {
+		if (! silent) fprintf(stderr, "instructions_million() not implemented\n");
+		test_skip(test_string);
+	}
+
+	struct perf_event_attr attr = {
+		.type=PERF_TYPE_HARDWARE,
+		.size=sizeof(struct perf_event_attr),
+		.config=PERF_COUNT_HW_INSTRUCTIONS,
+		.pinned = 1,
+	};
+
+	int fd = perf_event_open(&attr, 0, -1, -1, 0);
+	if (fd < 0) {				
+		if (! silent) perror("perf_event_open() failed");
+		test_fail(test_string);
+	}
+	
+	char *map = mmap(NULL, getpagesize(), PROT_READ, MAP_SHARED, fd, 0);
+	if (map == (void *)(-1)) {
+		if (! silent) perror("mmap() failed");
+		test_fail(test_string);
+	}
+
+	int repeat =  100000;
+	if (! quiet) printf("Trying up to %d iterations ", repeat);
+	int allowed = 10000000;
+	if (! quiet) printf("(%d allowed per iteration)\n", allowed);
+
+	unsigned long long max_count = 0;
+	for(int i = 0; i < repeat; i++) {
+		ioctl(fd, PERF_EVENT_IOC_RESET, 0);	
+		instructions_million();
+		unsigned long long count = mmap_read_self(map, NULL, NULL);
+		if (count > allowed) {
+			if (! silent) {
+				fprintf(stderr, "Got spurious count of %lld "
+					"in iteration %d\n", count, i);
+				fprintf(stderr, "Max count for previous "
+					"iterations was %lld\n", max_count);
+			}
+			test_fail(test_string);
+		}
+		if (count > max_count) max_count = count;
+	}
+
+	close(fd);
+	munmap(map, getpagesize());
+
+	if (! quiet) printf("Done. Max count was %lld\n", max_count);
+	test_pass(test_string);
+
+	return 0;
+}


### PR DESCRIPTION
I've been having problems using rdpmc to read hardware counters that are
set with perf_event_open().  I think the issue is that 'offset' field in
the mmap buffer periodically periodically has its high bit set.

Here's what I see when I run this test program on Skylake with Linux 4.4.4:

nate@skylake:~/git/perf_event_tests/tests/rdpmc$ rdpmc_jump
Testing if hardware counters exhibit unexpected jumps with rdpmc.
Trying up to 100000 iterations (10000000 allowed per iteration)
Got spurious count of 281474977720397 in iteration 230
Max count for previous iterations was 1010185
Testing if hardware counters exhibit unexpected jumps with rdpmc FAILED

nate@skylake:~/git/perf_event_tests/tests/rdpmc$ rdpmc_jump
Testing if hardware counters exhibit unexpected jumps with rdpmc.
Trying up to 100000 iterations (10000000 allowed per iteration)
Got spurious count of 281474977714973 in iteration 7295
Max count for previous iterations was 1007879
Testing if hardware counters exhibit unexpected jumps with rdpmc FAILED
