### PR TITLE
fuzzer: add EFAULT as known_errno

### DIFF
--- a/fuzzer/fuzz_open.c
+++ b/fuzzer/fuzz_open.c
@@ -201,6 +201,7 @@ static int known_errno(int e) {
 		case EBUSY:
 		case EAGAIN:
 		case EOVERFLOW:
+		case EFAULT:
 			return 1;
                 default:
 			return 0;


### PR DESCRIPTION
There is a possibility to get EFAULT in fuzzer, when perf_event_open().

Example, if we sanitise perf_event_attr.type as 7 to perf_event_open(), and 7 is the type of uprobe.

$ cat /sys/bus/event_source/devices/uprobe/type
7

Then the call chain should be something like this:
[   34.629645] Call Trace:
[   34.629655]  perf_uprobe_init.cold+0xf/0xc3
[   34.629660]  perf_uprobe_event_init+0x41/0x80
[   34.629666]  perf_try_init_event+0x59/0x112
[   34.629669]  perf_event_alloc+0x579/0xacd
[   34.629671]  ? printk+0x58/0x6f
[   34.629676]  __do_sys_perf_event_open+0x475/0xfa4
[   34.629683]  do_syscall_64+0x3b/0x90
[   34.629687]  entry_SYSCALL_64_after_hwframe+0x44/0xae

Therefore we will go into perf_uprobe_init() and we need to

         path = strndup_user(u64_to_user_ptr(p_event->attr.uprobe_path),
                             PATH_MAX);

that means, if we pass an invalid uprobe_path pointer, we will get EFAULT.

Signed-off-by: Ma Xinjian <maxj.fnst@fujitsu.com>